### PR TITLE
revise implementation of algorithm to calculate area of polygon on a …

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,14 +53,29 @@ function polygonArea(coords) {
  */
 
 function ringArea(coords) {
-    var area = 0;
+    var p1, p2, p3, lowerIndex, middleIndex, upperIndex,
+    area = 0,
+    coordsLength = coords.length;
 
-    if (coords.length > 2) {
-        var p1, p2;
-        for (var i = 0; i < coords.length - 1; i++) {
-            p1 = coords[i];
-            p2 = coords[i + 1];
-            area += rad(p2[0] - p1[0]) * (2 + Math.sin(rad(p1[1])) + Math.sin(rad(p2[1])));
+    if (coordsLength > 2) {
+        for (i = 0; i < coordsLength; i++) {
+            if (i === coordsLength - 2) {// i = N-2
+                lowerIndex = coordsLength - 2;
+                middleIndex = coordsLength -1;
+                upperIndex = 0;
+            } else if (i === coordsLength - 1) {// i = N-1
+                lowerIndex = coordsLength - 1;
+                middleIndex = 0;
+                upperIndex = 1;
+            } else { // i = 0 to N-3
+                lowerIndex = i;
+                middleIndex = i+1;
+                upperIndex = i+2;
+            }
+            p1 = coords[lowerIndex];
+            p2 = coords[middleIndex];
+            p3 = coords[upperIndex];
+            area += ( rad(p3[0]) - rad(p1[0]) ) * Math.sin( rad(p2[1]));
         }
 
         area = area * wgs84.RADIUS * wgs84.RADIUS / 2;

--- a/test/basic.js
+++ b/test/basic.js
@@ -5,7 +5,7 @@ var gjArea = require('../'),
 
 test('geojson area', function(t) {
     t.test('computes the area of illinois', function(t) {
-        t.equal(gjArea.geometry(ill), 145978332359.37125);
+        t.equal(gjArea.geometry(ill), 145978332359.36746);
         t.end();
     });
     // http://www.wolframalpha.com/input/?i=surface+area+of+earth


### PR DESCRIPTION
…sphere

  We are using your routines in our application and noticed that there were inconsistent results with the polygon area calculations on some areas of the map. I reviewed the reference you provided "Some Algorithms for Polygons on a Sphere" and implemented the formula for 'area of a polygon on a sphere' on page 7. As a result, we believe that we are getting better results.
I compared the results with an online calculator I found at GeographicLib (http://geographiclib.sourceforge.net/scripts/geod-calc.html).  The new implementation yields a 0.4% error. Your implementation had a 13% error with the following sample data of a 6 point polygon:
// [longitude, latitude] pairs
var test_poly = [
    [ -16.7431640625, 2.2406396093827463],
    [ -8.6572265625, 7.536764322084078],
    [ -0.3515625, 2.723583083348411],
    [ -2.4169921875, -7.754537346539373],
    [ -11.0302734375, -10.22843726615593],
    [ -17.2705078125, -5.922044619883292]
];

best regards
