### PR TITLE
Support 'use strict'

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ function polygonArea(coords) {
  */
 
 function ringArea(coords) {
-    var p1, p2, p3, lowerIndex, middleIndex, upperIndex,
+    var p1, p2, p3, lowerIndex, middleIndex, upperIndex, i,
     area = 0,
     coordsLength = coords.length;
 


### PR DESCRIPTION
When loading this file via babel/webpack which adds "use strict" by
default it throws an error because "i" is not defined.

I've added "i" to the var list at the beginning of the "ringArea"
function.