### PR TITLE
Add TypeScript type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+declare module '@mapbox/geojson-area' {
+  import { Geometry } from 'geojson';
+
+  export function geometry(geo: Geometry): number;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.2.2",
   "description": "calculate the physical area of a geojson geometry",
   "main": "index.js",
+  "types": "index.d.ts",
   "directories": {
     "test": "test"
   },
@@ -24,6 +25,7 @@
     "wgs84": "0.0.0"
   },
   "devDependencies": {
+    "@types/geojson": "^7946.0.3",
     "cz-conventional-changelog": "^1.2.0",
     "tape": "^3.0.3"
   },


### PR DESCRIPTION
This introduces TypeScript declarations as part of the published package, as per the instructions at:
http://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

Note that this also brings in a development dependency for [`@types/geojson`](https://www.npmjs.com/package/@types/geojson) to enforce the `Geometry` argument type.